### PR TITLE
Refactor reveal_shifted signal to be one dimention

### DIFF
--- a/compiler/tpl.circom
+++ b/compiler/tpl.circom
@@ -8,7 +8,8 @@ template TEMPLATE_NAME_PLACEHOLDER (msg_bytes, reveal_bytes) {
     signal output start_idx;
     signal output out;
 
-    signal output reveal_shifted[reveal_bytes][msg_bytes];
+    signal reveal_shifted_intermediate[reveal_bytes][msg_bytes];
+    signal output reveal_shifted[reveal_bytes];
 
     var num_bytes = msg_bytes;
     signal in[num_bytes];
@@ -68,11 +69,12 @@ template TEMPLATE_NAME_PLACEHOLDER (msg_bytes, reveal_bytes) {
     }
 
     for (var j = 0; j < reveal_bytes; j++) {
-        reveal_shifted[j][j] <== 0;
+        reveal_shifted_intermediate[j][j] <== 0;
         for (var i = j + 1; i < msg_bytes; i++) {
             // This shifts matched string back to the beginning. 
-            reveal_shifted[j][i] <== reveal_shifted[j][i - 1] + match_start_idx[i-j].out * reveal_match[i];
+            reveal_shifted_intermediate[j][i] <== reveal_shifted_intermediate[j][i - 1] + match_start_idx[i-j].out * reveal_match[i];
         }
+        reveal_shifted[j] <== reveal_shifted_intermediate[j][msg_bytes - 1];
     }
 
     out <== count;

--- a/test/regex-compiler.test.ts
+++ b/test/regex-compiler.test.ts
@@ -19,14 +19,8 @@ describe("regex compiler tests", function () {
             '1st match in the middle', 
             [`email was meant for @(${generator.word_char}+)`, 1],
             (signals: any) => {
-                const to_reveal = 'katat'.split('').map((x: any) => BigInt(x.charCodeAt(0)))
-                for (let m in signals.main.reveal_shifted) {
-                    const index = signals.main.reveal_shifted[m]
-                    const last_pos = index.length - 1
-                    if (to_reveal[m as any]) {
-                        expect(index[last_pos]).to.equal(to_reveal[m as any])
-                    }
-                }
+                const expected_reveal = 'katat'.split('').map((x: any) => BigInt(x.charCodeAt(0)))
+                assert_reveal(signals, expected_reveal);
                 expect(signals.main.out).to.equal(2n)
                 expect(signals.main.start_idx).to.equal(28n)
             }
@@ -35,14 +29,8 @@ describe("regex compiler tests", function () {
             '2nd match in the middle', 
             [`email was meant for @(${generator.word_char}+)`, 2],
             (signals: any) => {
-                const to_reveal = 'katat'.split('').map((x: any) => BigInt(x.charCodeAt(0)))
-                for (let m in signals.main.reveal_shifted) {
-                    const index = signals.main.reveal_shifted[m]
-                    const last_pos = index.length - 1
-                    if (to_reveal[m as any]) {
-                        expect(index[last_pos]).to.equal(to_reveal[m as any])
-                    }
-                }
+                const expected_reveal = 'katat'.split('').map((x: any) => BigInt(x.charCodeAt(0)))
+                assert_reveal(signals, expected_reveal);
                 expect(signals.main.out).to.equal(2n)
                 expect(signals.main.start_idx).to.equal(67n)
             }
@@ -96,3 +84,12 @@ describe("regex compiler tests", function () {
         });
     });
 });
+
+function assert_reveal(signals: any, expected_reveal: bigint[]) {
+    for (let m in signals.main.reveal_shifted) {
+        const value = signals.main.reveal_shifted[m];
+        if (expected_reveal[m as any]) {
+            expect(value).to.equal(expected_reveal[m as any]);
+        }
+    }
+}


### PR DESCRIPTION
This simplify the output signal reveal_shifted to be one dimentional, so that the downstream is not required to extract the value from the last element in the second dimention of the array. 